### PR TITLE
Switched event to later

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1056,16 +1056,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.38.2",
+            "version": "v11.39.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "9d290aa90fcad44048bedca5219d2b872e98772a"
+                "reference": "3d693dd36e78121bcd51fc02eda4bc137d2a17f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/9d290aa90fcad44048bedca5219d2b872e98772a",
-                "reference": "9d290aa90fcad44048bedca5219d2b872e98772a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/3d693dd36e78121bcd51fc02eda4bc137d2a17f2",
+                "reference": "3d693dd36e78121bcd51fc02eda4bc137d2a17f2",
                 "shasum": ""
             },
             "require": {
@@ -1266,7 +1266,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-01-15T00:06:46+00:00"
+            "time": "2025-01-22T17:01:46+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/src/PhpUnit/RecordRenderedViews.php
+++ b/src/PhpUnit/RecordRenderedViews.php
@@ -2,14 +2,15 @@
 
 namespace AnthonyEdmonds\LaravelTestingTraits\PhpUnit;
 
-use PHPUnit\Event\Test\Prepared;
-use PHPUnit\Event\Test\PreparedSubscriber;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Event\Test\BeforeFirstTestMethodCalled;
+use PHPUnit\Event\Test\BeforeFirstTestMethodCalledSubscriber;
 
-class RecordRenderedViews implements PreparedSubscriber
+class RecordRenderedViews implements BeforeFirstTestMethodCalledSubscriber
 {
-    public function notify(Prepared $event): void
+    public function notify(BeforeFirstTestMethodCalled $event): void
     {
-        app('events')->listen('composing:*', function (string $view) {
+        Event::listen('composing:*', function (string $view) {
             if (str_contains($view, '::') === false) {
                 file_put_contents(
                     AssertAllViewsRenderedExtension::path(),


### PR DESCRIPTION
Some systems were reporting that `events` had not been registered under app.

Switching the event now means that the app should be fully booted before this is registered.